### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/app/api/contest/route.ts
+++ b/app/api/contest/route.ts
@@ -5,9 +5,16 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const contestCode = searchParams.get("code");
 
+  // Validate contestCode: only allow alphanumeric, underscores and hyphens
   if (!contestCode) {
     return NextResponse.json(
       { error: "Contest code is required" },
+      { status: 400 },
+    );
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(contestCode)) {
+    return NextResponse.json(
+      { error: "Invalid contest code format" },
       { status: 400 },
     );
   }


### PR DESCRIPTION
Potential fix for [https://github.com/ashishpawar517/codechef-contest-tracker/security/code-scanning/5](https://github.com/ashishpawar517/codechef-contest-tracker/security/code-scanning/5)

The fix is to strictly validate and sanitize the `contestCode` value before using it in the outbound API request. This ensures that `contestCode` only matches the expected format (as assigned by Codechef). For contest codes, the expected pattern is typically an alphanumeric string, possibly with underscores or hyphens, no slashes, dots, or other special URL characters. Therefore:
- Enforce validation via a regular expression matching only acceptable contest code patterns (e.g., `/^[A-Za-z0-9_-]+$/`).
- If the code fails validation, immediately return a 400 Bad Request error.
- No need to escape or encode further, as the input cannot break the intended semantics.

You only need to add a validation step just after reading in `contestCode` (after line 6, before the "required" check, or just after line 13). If validation fails, mirror the error handling for missing values.

No additional library imports are needed; regex validation is provided natively by JavaScript/TypeScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
